### PR TITLE
feat: add NestJS backend with auth and Prisma

### DIFF
--- a/backend-nest/.env.example
+++ b/backend-nest/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nest?schema=public"
+JWT_SECRET="change_this_secret"

--- a/backend-nest/.gitignore
+++ b/backend-nest/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+dist
+.env
+

--- a/backend-nest/docker-compose.yml
+++ b/backend-nest/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:13
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: nest
+    ports:
+      - '5432:5432'
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:

--- a/backend-nest/jest.config.js
+++ b/backend-nest/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/backend-nest/nest-cli.json
+++ b/backend-nest/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/backend-nest/package.json
+++ b/backend-nest/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "backend-nest",
+  "version": "1.0.0",
+  "description": "NestJS backend with Prisma for users and products",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "nest build",
+    "start": "node dist/main.js",
+    "start:dev": "nest start --watch",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/jwt": "^10.0.0",
+    "@nestjs/passport": "^10.0.0",
+    "@prisma/client": "^5.0.0",
+    "bcrypt": "^5.1.0",
+    "passport": "^0.7.0",
+    "passport-jwt": "^4.0.1",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/testing": "^10.0.0",
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.0",
+    "@types/node": "^20.10.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0",
+    "prisma": "^5.0.0"
+  }
+}

--- a/backend-nest/prisma/schema.prisma
+++ b/backend-nest/prisma/schema.prisma
@@ -1,0 +1,22 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id       Int       @id @default(autoincrement())
+  email    String    @unique
+  password String
+  products Product[]
+}
+
+model Product {
+  id     Int    @id @default(autoincrement())
+  name   String
+  user   User   @relation(fields: [userId], references: [id])
+  userId Int
+}

--- a/backend-nest/src/app.module.ts
+++ b/backend-nest/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { UsersModule } from './users/users.module';
+import { AuthModule } from './auth/auth.module';
+import { ProductsModule } from './products/products.module';
+import { PrismaModule } from './prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule, UsersModule, AuthModule, ProductsModule],
+})
+export class AppModule {}

--- a/backend-nest/src/auth/auth.controller.ts
+++ b/backend-nest/src/auth/auth.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private authService: AuthService) {}
+
+  @Post('login')
+  login(@Body() body: { email: string; password: string }) {
+    return this.authService.login(body.email, body.password);
+  }
+}

--- a/backend-nest/src/auth/auth.module.ts
+++ b/backend-nest/src/auth/auth.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { UsersModule } from '../users/users.module';
+import { JwtStrategy } from './jwt.strategy';
+
+@Module({
+  imports: [
+    UsersModule,
+    JwtModule.register({
+      secret: process.env.JWT_SECRET || 'change_this_secret',
+      signOptions: { expiresIn: '1h' },
+    }),
+  ],
+  providers: [AuthService, JwtStrategy],
+  controllers: [AuthController],
+  exports: [JwtModule],
+})
+export class AuthModule {}

--- a/backend-nest/src/auth/auth.service.ts
+++ b/backend-nest/src/auth/auth.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { UsersService } from '../users/users.service';
+import { JwtService } from '@nestjs/jwt';
+import * as bcrypt from 'bcrypt';
+
+@Injectable()
+export class AuthService {
+  constructor(private usersService: UsersService, private jwtService: JwtService) {}
+
+  async validateUser(email: string, pass: string) {
+    const user = await this.usersService.findByEmail(email);
+    if (user && await bcrypt.compare(pass, user.password)) {
+      return user;
+    }
+    return null;
+  }
+
+  async login(email: string, pass: string) {
+    const user = await this.validateUser(email, pass);
+    if (!user) throw new UnauthorizedException();
+    const payload = { sub: user.id, email: user.email };
+    return { access_token: await this.jwtService.signAsync(payload) };
+  }
+}

--- a/backend-nest/src/auth/jwt-auth.guard.ts
+++ b/backend-nest/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/backend-nest/src/auth/jwt.strategy.ts
+++ b/backend-nest/src/auth/jwt.strategy.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: process.env.JWT_SECRET || 'change_this_secret',
+    });
+  }
+
+  async validate(payload: any) {
+    return { userId: payload.sub, email: payload.email };
+  }
+}

--- a/backend-nest/src/main.ts
+++ b/backend-nest/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/backend-nest/src/prisma/prisma.module.ts
+++ b/backend-nest/src/prisma/prisma.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/backend-nest/src/prisma/prisma.service.ts
+++ b/backend-nest/src/prisma/prisma.service.ts
@@ -1,0 +1,13 @@
+import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}

--- a/backend-nest/src/products/dto/create-product.dto.ts
+++ b/backend-nest/src/products/dto/create-product.dto.ts
@@ -1,0 +1,3 @@
+export class CreateProductDto {
+  name: string;
+}

--- a/backend-nest/src/products/products.controller.ts
+++ b/backend-nest/src/products/products.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Post, Body, UseGuards, Request } from '@nestjs/common';
+import { ProductsService } from './products.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CreateProductDto } from './dto/create-product.dto';
+
+@Controller('products')
+export class ProductsController {
+  constructor(private productsService: ProductsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  create(@Body() dto: CreateProductDto, @Request() req) {
+    return this.productsService.create(dto.name, req.user.userId);
+  }
+
+  @Get()
+  findAll() {
+    return this.productsService.findAll();
+  }
+}

--- a/backend-nest/src/products/products.module.ts
+++ b/backend-nest/src/products/products.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProductsService } from './products.service';
+import { ProductsController } from './products.controller';
+
+@Module({
+  controllers: [ProductsController],
+  providers: [ProductsService],
+})
+export class ProductsModule {}

--- a/backend-nest/src/products/products.service.ts
+++ b/backend-nest/src/products/products.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class ProductsService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(name: string, userId: number) {
+    return this.prisma.product.create({ data: { name, userId } });
+  }
+
+  findAll() {
+    return this.prisma.product.findMany();
+  }
+}

--- a/backend-nest/src/users/dto/create-user.dto.ts
+++ b/backend-nest/src/users/dto/create-user.dto.ts
@@ -1,0 +1,4 @@
+export class CreateUserDto {
+  email: string;
+  password: string;
+}

--- a/backend-nest/src/users/users.controller.ts
+++ b/backend-nest/src/users/users.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { CreateUserDto } from './dto/create-user.dto';
+
+@Controller('users')
+export class UsersController {
+  constructor(private usersService: UsersService) {}
+
+  @Post()
+  create(@Body() dto: CreateUserDto) {
+    return this.usersService.create(dto);
+  }
+}

--- a/backend-nest/src/users/users.module.ts
+++ b/backend-nest/src/users/users.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
+
+@Module({
+  controllers: [UsersController],
+  providers: [UsersService],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/backend-nest/src/users/users.service.ts
+++ b/backend-nest/src/users/users.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import * as bcrypt from 'bcrypt';
+
+@Injectable()
+export class UsersService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(data: CreateUserDto) {
+    const hashed = await bcrypt.hash(data.password, 10);
+    return this.prisma.user.create({ data: { email: data.email, password: hashed } });
+  }
+
+  async findByEmail(email: string) {
+    return this.prisma.user.findUnique({ where: { email } });
+  }
+}

--- a/backend-nest/tsconfig.build.json
+++ b/backend-nest/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "removeComments": true,
+    "declaration": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/backend-nest/tsconfig.json
+++ b/backend-nest/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold NestJS backend with Prisma service
- add auth login with JWT and secured product creation
- provide docker-compose for PostgreSQL

## Testing
- `npm test` (fails: jest: not found)
- `npm run build` (fails: nest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68923eeb0368832f89e577e1b2d8f29a