### PR TITLE
feat: add swagger documentation

### DIFF
--- a/backend-nest/package.json
+++ b/backend-nest/package.json
@@ -20,7 +20,9 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "@nestjs/swagger": "^7.1.3",
+    "swagger-ui-express": "^4.6.3"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/backend-nest/src/auth/auth.controller.ts
+++ b/backend-nest/src/auth/auth.controller.ts
@@ -1,12 +1,16 @@
 import { Controller, Post, Body } from '@nestjs/common';
+import { ApiTags, ApiBody } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
+import { LoginDto } from './dto/login.dto';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private authService: AuthService) {}
 
   @Post('login')
-  login(@Body() body: { email: string; password: string }) {
+  @ApiBody({ type: LoginDto })
+  login(@Body() body: LoginDto) {
     return this.authService.login(body.email, body.password);
   }
 }

--- a/backend-nest/src/auth/dto/login.dto.ts
+++ b/backend-nest/src/auth/dto/login.dto.ts
@@ -1,9 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class CreateUserDto {
+export class LoginDto {
   @ApiProperty()
   email: string;
 
   @ApiProperty()
   password: string;
 }
+

--- a/backend-nest/src/main.ts
+++ b/backend-nest/src/main.ts
@@ -1,8 +1,17 @@
 import { NestFactory } from '@nestjs/core';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const config = new DocumentBuilder()
+    .setTitle('API')
+    .setDescription('API documentation')
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
   await app.listen(3000);
 }
 bootstrap();

--- a/backend-nest/src/products/dto/create-product.dto.ts
+++ b/backend-nest/src/products/dto/create-product.dto.ts
@@ -1,3 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class CreateProductDto {
+  @ApiProperty()
   name: string;
 }

--- a/backend-nest/src/products/products.controller.ts
+++ b/backend-nest/src/products/products.controller.ts
@@ -1,14 +1,18 @@
 import { Controller, Get, Post, Body, UseGuards, Request } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiBody } from '@nestjs/swagger';
 import { ProductsService } from './products.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CreateProductDto } from './dto/create-product.dto';
 
+@ApiTags('products')
+@ApiBearerAuth()
 @Controller('products')
 export class ProductsController {
   constructor(private productsService: ProductsService) {}
 
   @UseGuards(JwtAuthGuard)
   @Post()
+  @ApiBody({ type: CreateProductDto })
   create(@Body() dto: CreateProductDto, @Request() req) {
     return this.productsService.create(dto.name, req.user.userId);
   }

--- a/backend-nest/src/users/users.controller.ts
+++ b/backend-nest/src/users/users.controller.ts
@@ -1,12 +1,15 @@
 import { Controller, Post, Body } from '@nestjs/common';
+import { ApiTags, ApiBody } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 
+@ApiTags('users')
 @Controller('users')
 export class UsersController {
   constructor(private usersService: UsersService) {}
 
   @Post()
+  @ApiBody({ type: CreateUserDto })
   create(@Body() dto: CreateUserDto) {
     return this.usersService.create(dto);
   }


### PR DESCRIPTION
## Summary
- integrate Swagger and serve docs at `/api`
- annotate auth, products, and users endpoints with Swagger metadata
- add DTOs for structured request bodies

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68924a493144832fb0e89b26f0e72c5f